### PR TITLE
Hack around std::bad_cast compilation errors

### DIFF
--- a/dependencies/include/asio/detail/impl/win_iocp_io_service.ipp
+++ b/dependencies/include/asio/detail/impl/win_iocp_io_service.ipp
@@ -467,7 +467,7 @@ DWORD win_iocp_io_service::get_gqcs_timeout()
     // @third party code Studio Gobo
     // Hack to get project compiling on UWP as ::TerminateThread is not available on that platform
     // https://docs.microsoft.com/en-us/windows/desktop/api/processthreadsapi/nf-processthreadsapi-terminatethread
-#if !ES_MODIFICATIONS
+#if !ES_RPCLIB_MODIFICATIONS
   const uint64_t condition_mask = ::VerSetConditionMask(
     0, VER_MAJORVERSION, VER_GREATER_EQUAL);
   if (!!::VerifyVersionInfo(&osvi, VER_MAJORVERSION, condition_mask))

--- a/dependencies/include/asio/detail/impl/win_iocp_io_service.ipp
+++ b/dependencies/include/asio/detail/impl/win_iocp_io_service.ipp
@@ -15,10 +15,6 @@
 # pragma once
 #endif // defined(_MSC_VER) && (_MSC_VER >= 1200)
 
-// @third party code Studio Gobo
-#include "assert.h"
-// @third party code Studio Gobo
-
 #include "asio/detail/config.hpp"
 
 #if defined(ASIO_HAS_IOCP)
@@ -471,7 +467,7 @@ DWORD win_iocp_io_service::get_gqcs_timeout()
     // @third party code Studio Gobo
     // Hack to get project compiling on UWP as ::TerminateThread is not available on that platform
     // https://docs.microsoft.com/en-us/windows/desktop/api/processthreadsapi/nf-processthreadsapi-terminatethread
-#if false
+#if !ES_MODIFICATIONS
   const uint64_t condition_mask = ::VerSetConditionMask(
     0, VER_MAJORVERSION, VER_GREATER_EQUAL);
   if (!!::VerifyVersionInfo(&osvi, VER_MAJORVERSION, condition_mask))

--- a/dependencies/include/asio/detail/impl/win_iocp_io_service.ipp
+++ b/dependencies/include/asio/detail/impl/win_iocp_io_service.ipp
@@ -15,6 +15,10 @@
 # pragma once
 #endif // defined(_MSC_VER) && (_MSC_VER >= 1200)
 
+// @third party code Studio Gobo
+#include "assert.h"
+// @third party code Studio Gobo
+
 #include "asio/detail/config.hpp"
 
 #if defined(ASIO_HAS_IOCP)
@@ -462,11 +466,18 @@ DWORD win_iocp_io_service::get_gqcs_timeout()
   osvi.dwOSVersionInfoSize = sizeof(osvi);
   osvi.dwMajorVersion = 6ul;
 
-  const uint64_t condition_mask = ::VerSetConditionMask(
-      0, VER_MAJORVERSION, VER_GREATER_EQUAL);
 
+  
+    // @third party code Studio Gobo
+    // Hack to get project compiling on UWP as ::TerminateThread is not available on that platform
+    // https://docs.microsoft.com/en-us/windows/desktop/api/processthreadsapi/nf-processthreadsapi-terminatethread
+#if false
+  const uint64_t condition_mask = ::VerSetConditionMask(
+    0, VER_MAJORVERSION, VER_GREATER_EQUAL);
   if (!!::VerifyVersionInfo(&osvi, VER_MAJORVERSION, condition_mask))
     return INFINITE;
+#endif
+    // @third party code Studio Gobo
 
   return default_gqcs_timeout;
 }

--- a/dependencies/include/asio/detail/impl/win_iocp_io_service.ipp
+++ b/dependencies/include/asio/detail/impl/win_iocp_io_service.ipp
@@ -467,7 +467,7 @@ DWORD win_iocp_io_service::get_gqcs_timeout()
     // @third party code Studio Gobo
     // Hack to get project compiling on UWP as ::TerminateThread is not available on that platform
     // https://docs.microsoft.com/en-us/windows/desktop/api/processthreadsapi/nf-processthreadsapi-terminatethread
-#if !ES_RPCLIB_MODIFICATIONS
+#if ES_ALLOW_WSA_INCOMPATIBLE_CODE
   const uint64_t condition_mask = ::VerSetConditionMask(
     0, VER_MAJORVERSION, VER_GREATER_EQUAL);
   if (!!::VerifyVersionInfo(&osvi, VER_MAJORVERSION, condition_mask))

--- a/dependencies/include/asio/detail/impl/win_thread.ipp
+++ b/dependencies/include/asio/detail/impl/win_thread.ipp
@@ -51,7 +51,7 @@ void win_thread::join()
     // @third party code Studio Gobo
     // Hack to get project compiling on UWP as ::TerminateThread is not available on that platform
     // https://docs.microsoft.com/en-us/windows/desktop/api/processthreadsapi/nf-processthreadsapi-terminatethread
-#if !ES_MODIFICATIONS
+#if !ES_RPCLIB_MODIFICATIONS
     ::TerminateThread(thread_, 0);
 #else
     assert(false);

--- a/dependencies/include/asio/detail/impl/win_thread.ipp
+++ b/dependencies/include/asio/detail/impl/win_thread.ipp
@@ -19,6 +19,10 @@
 
 #if defined(ASIO_WINDOWS) && !defined(UNDER_CE)
 
+// @third party code Studio Gobo
+#include <assert.h>
+// @third party code Studio Gobo
+
 #include <process.h>
 #include "asio/detail/throw_error.hpp"
 #include "asio/detail/win_thread.hpp"
@@ -44,7 +48,15 @@ void win_thread::join()
   ::CloseHandle(exit_event_);
   if (terminate_threads())
   {
+    // @third party code Studio Gobo
+    // Hack to get project compiling on UWP as ::TerminateThread is not available on that platform
+    // https://docs.microsoft.com/en-us/windows/desktop/api/processthreadsapi/nf-processthreadsapi-terminatethread
+#if false
     ::TerminateThread(thread_, 0);
+#else
+    assert(false);
+#endif
+    // @third party code Studio Gobo
   }
   else
   {

--- a/dependencies/include/asio/detail/impl/win_thread.ipp
+++ b/dependencies/include/asio/detail/impl/win_thread.ipp
@@ -51,7 +51,7 @@ void win_thread::join()
     // @third party code Studio Gobo
     // Hack to get project compiling on UWP as ::TerminateThread is not available on that platform
     // https://docs.microsoft.com/en-us/windows/desktop/api/processthreadsapi/nf-processthreadsapi-terminatethread
-#if !ES_RPCLIB_MODIFICATIONS
+#if ES_ALLOW_WSA_INCOMPATIBLE_CODE
     ::TerminateThread(thread_, 0);
 #else
     assert(false);

--- a/dependencies/include/asio/detail/impl/win_thread.ipp
+++ b/dependencies/include/asio/detail/impl/win_thread.ipp
@@ -51,7 +51,7 @@ void win_thread::join()
     // @third party code Studio Gobo
     // Hack to get project compiling on UWP as ::TerminateThread is not available on that platform
     // https://docs.microsoft.com/en-us/windows/desktop/api/processthreadsapi/nf-processthreadsapi-terminatethread
-#if false
+#if !ES_MODIFICATIONS
     ::TerminateThread(thread_, 0);
 #else
     assert(false);

--- a/dependencies/include/asio/generic/datagram_protocol.hpp
+++ b/dependencies/include/asio/generic/datagram_protocol.hpp
@@ -67,7 +67,9 @@ public:
   {
     if (source_protocol.type() != type())
     {
-      std::bad_cast ex;
+       // @third party code Studio Gobo
+      std::exception ex;
+       // @third party code Studio Gobo
       clmdep_asio::detail::throw_exception(ex);
     }
   }

--- a/dependencies/include/asio/generic/raw_protocol.hpp
+++ b/dependencies/include/asio/generic/raw_protocol.hpp
@@ -67,7 +67,9 @@ public:
   {
     if (source_protocol.type() != type())
     {
-      std::bad_cast ex;
+       // @third party code Studio Gobo
+      std::exception ex;
+       // @third party code Studio Gobo
       clmdep_asio::detail::throw_exception(ex);
     }
   }

--- a/dependencies/include/asio/generic/seq_packet_protocol.hpp
+++ b/dependencies/include/asio/generic/seq_packet_protocol.hpp
@@ -66,7 +66,9 @@ public:
   {
     if (source_protocol.type() != type())
     {
-      std::bad_cast ex;
+       // @third party code Studio Gobo
+      std::exception ex;
+       // @third party code Studio Gobo
       clmdep_asio::detail::throw_exception(ex);
     }
   }

--- a/dependencies/include/asio/generic/stream_protocol.hpp
+++ b/dependencies/include/asio/generic/stream_protocol.hpp
@@ -68,7 +68,9 @@ public:
   {
     if (source_protocol.type() != type())
     {
-      std::bad_cast ex;
+       // @third party code Studio Gobo
+      std::exception ex;
+       // @third party code Studio Gobo
       clmdep_asio::detail::throw_exception(ex);
     }
   }

--- a/dependencies/include/asio/ip/impl/address.ipp
+++ b/dependencies/include/asio/ip/impl/address.ipp
@@ -103,7 +103,9 @@ clmdep_asio::ip::address_v4 address::to_v4() const
 {
   if (type_ != ipv4)
   {
-    std::bad_cast ex;
+    // @third party code Studio Gobo
+    std::exception ex;
+    // @third party code Studio Gobo
     clmdep_asio::detail::throw_exception(ex);
   }
   return ipv4_address_;
@@ -113,7 +115,9 @@ clmdep_asio::ip::address_v6 address::to_v6() const
 {
   if (type_ != ipv6)
   {
-    std::bad_cast ex;
+    // @third party code Studio Gobo
+    std::exception ex;
+    // @third party code Studio Gobo
     clmdep_asio::detail::throw_exception(ex);
   }
   return ipv6_address_;

--- a/dependencies/include/asio/ip/impl/address_v6.ipp
+++ b/dependencies/include/asio/ip/impl/address_v6.ipp
@@ -150,7 +150,9 @@ address_v4 address_v6::to_v4() const
 {
   if (!is_v4_mapped() && !is_v4_compatible())
   {
-    std::bad_cast ex;
+    // @third party code Studio Gobo
+    std::exception ex;
+    // @third party code Studio Gobo
     clmdep_asio::detail::throw_exception(ex);
   }
 

--- a/include/rpc/msgpack/v1/object_fwd.hpp
+++ b/include/rpc/msgpack/v1/object_fwd.hpp
@@ -233,7 +233,9 @@ public:
     implicit_type convert() const;
 };
 
-class type_error : public std::bad_cast { };
+// @third party code Studio Gobo
+class type_error : public std::exception { };
+// @third party code Studio Gobo
 
 struct object::implicit_type {
     implicit_type(object const& o) : obj(o) { }

--- a/include/rpc/nonstd/optional.hpp
+++ b/include/rpc/nonstd/optional.hpp
@@ -763,7 +763,7 @@ public:
     optional_constexpr14 value_type const & value() const optional_ref_qual
     {
         // @third party code Studio Gobo
-#if !ES_RPCLIB_MODIFICATIONS
+#if ES_ALLOW_WSA_INCOMPATIBLE_CODE
         if ( ! has_value() )
             throw bad_optional_access();
 #else
@@ -777,7 +777,7 @@ public:
     optional_constexpr14 value_type & value() optional_ref_qual
     {
         // @third party code Studio Gobo
-#if !ES_RPCLIB_MODIFICATIONS
+#if ES_ALLOW_WSA_INCOMPATIBLE_CODE
         if ( ! has_value() )
             throw bad_optional_access();
 #else
@@ -793,7 +793,7 @@ public:
     optional_constexpr14 value_type const && value() const optional_refref_qual
     {
         // @third party code Studio Gobo
-#if !ES_RPCLIB_MODIFICATIONS
+#if ES_ALLOW_WSA_INCOMPATIBLE_CODE
         if ( ! has_value() )
             throw bad_optional_access();
 #else
@@ -807,7 +807,7 @@ public:
     optional_constexpr14 value_type && value() optional_refref_qual
     {
         // @third party code Studio Gobo
-#if !ES_RPCLIB_MODIFICATIONS
+#if ES_ALLOW_WSA_INCOMPATIBLE_CODE
         if ( ! has_value() )
             throw bad_optional_access();
 #else

--- a/include/rpc/nonstd/optional.hpp
+++ b/include/rpc/nonstd/optional.hpp
@@ -762,16 +762,28 @@ public:
 
     optional_constexpr14 value_type const & value() const optional_ref_qual
     {
+        // @third party code Studio Gobo
+#if !ES_RPCLIB_MODIFICATIONS
         if ( ! has_value() )
             throw bad_optional_access();
+#else
+        assert(has_value);
+#endif
+        // @third party code Studio Gobo
 
         return contained.value();
     }
 
     optional_constexpr14 value_type & value() optional_ref_qual
     {
+        // @third party code Studio Gobo
+#if !ES_RPCLIB_MODIFICATIONS
         if ( ! has_value() )
             throw bad_optional_access();
+#else
+        assert(has_value);
+#endif
+        // @third party code Studio Gobo
 
         return contained.value();
     }
@@ -780,16 +792,28 @@ public:
 
     optional_constexpr14 value_type const && value() const optional_refref_qual
     {
+        // @third party code Studio Gobo
+#if !ES_RPCLIB_MODIFICATIONS
         if ( ! has_value() )
             throw bad_optional_access();
+#else
+        assert(has_value);
+#endif
+        // @third party code Studio Gobo
 
         return std::move( contained.value() );
     }
 
     optional_constexpr14 value_type && value() optional_refref_qual
     {
+        // @third party code Studio Gobo
+#if !ES_RPCLIB_MODIFICATIONS
         if ( ! has_value() )
             throw bad_optional_access();
+#else
+        assert(has_value);
+#endif
+        // @third party code Studio Gobo
 
         return std::move( contained.value() );
     }

--- a/include/rpc/server.h
+++ b/include/rpc/server.h
@@ -79,8 +79,10 @@ public:
     //! \param worker_threads The number of worker threads to start.
     void async_run(std::size_t worker_threads = 1);
 
+    // @third party code Studio Gobo
     //! \brief polls the server queue and runs any pending RPC requests.
     void process_pending_requests();
+    // @third party code Studio Gobo
 
     //! \brief Binds a functor to a name so it becomes callable via RPC.
     //!

--- a/lib/rpc/server.cc
+++ b/lib/rpc/server.cc
@@ -124,7 +124,9 @@ void server::async_run(std::size_t worker_threads) {
     });
 }
 
+// @third party code Studio Gobo
 void server::process_pending_requests() { pimpl->io_.poll(); }
+// @third party code Studio Gobo
 
 void server::stop() { pimpl->stop(); }
 

--- a/vc14.1/rpclib/rcplib.windows/rpclib.windows.vcxproj
+++ b/vc14.1/rpclib/rcplib.windows/rpclib.windows.vcxproj
@@ -111,7 +111,7 @@
       <SDLCheck>
       </SDLCheck>
       <AdditionalIncludeDirectories>$(SolutionDir)..\..\include;$(SolutionDir)..\..\dependencies\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <PreprocessorDefinitions>WIN32;_WINDOWS;WIN32_LEAN_AND_MEAN;NOMINMAX;VC_EXTRALEAN;_CRT_SECURE_NO_WARNINGS;_CRT_NONSTDC_NO_DEPRECATE;_WIN32_WINNT=0x0501;_GNU_SOURCE;ASIO_HAS_STD_ADDRESSOF;ASIO_HAS_STD_ARRAY;ASIO_HAS_CSTDINT;ASIO_HAS_STD_SHARED_PTR;ASIO_HAS_STD_TYPE_TRAITS;ASIO_STANDALONE;RPCLIB_ASIO=clmdep_asio;RPCLIB_FMT=clmdep_fmt;RPCLIB_WIN32;RPCLIB_MSGPACK=clmdep_msgpack;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>ES_MODIFICATIONS;WIN32;_WINDOWS;WIN32_LEAN_AND_MEAN;NOMINMAX;VC_EXTRALEAN;_CRT_SECURE_NO_WARNINGS;_CRT_NONSTDC_NO_DEPRECATE;_WIN32_WINNT=0x0501;_GNU_SOURCE;ASIO_HAS_STD_ADDRESSOF;ASIO_HAS_STD_ARRAY;ASIO_HAS_CSTDINT;ASIO_HAS_STD_SHARED_PTR;ASIO_HAS_STD_TYPE_TRAITS;ASIO_STANDALONE;RPCLIB_ASIO=clmdep_asio;RPCLIB_FMT=clmdep_fmt;RPCLIB_WIN32;RPCLIB_MSGPACK=clmdep_msgpack;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <CompileAs>CompileAsCpp</CompileAs>
       <InlineFunctionExpansion>Disabled</InlineFunctionExpansion>
       <RuntimeTypeInfo>true</RuntimeTypeInfo>
@@ -134,7 +134,7 @@
       <SDLCheck>
       </SDLCheck>
       <AdditionalIncludeDirectories>$(SolutionDir)..\..\include;$(SolutionDir)..\..\dependencies\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <PreprocessorDefinitions>WIN32;_WINDOWS;WIN32_LEAN_AND_MEAN;NOMINMAX;VC_EXTRALEAN;_CRT_SECURE_NO_WARNINGS;_CRT_NONSTDC_NO_DEPRECATE;_WIN32_WINNT=0x0501;_GNU_SOURCE;ASIO_HAS_STD_ADDRESSOF;ASIO_HAS_STD_ARRAY;ASIO_HAS_CSTDINT;ASIO_HAS_STD_SHARED_PTR;ASIO_HAS_STD_TYPE_TRAITS;ASIO_STANDALONE;RPCLIB_ASIO=clmdep_asio;RPCLIB_FMT=clmdep_fmt;RPCLIB_WIN32;RPCLIB_MSGPACK=clmdep_msgpack;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>ES_MODIFICATIONS;WIN32;_WINDOWS;WIN32_LEAN_AND_MEAN;NOMINMAX;VC_EXTRALEAN;_CRT_SECURE_NO_WARNINGS;_CRT_NONSTDC_NO_DEPRECATE;_WIN32_WINNT=0x0501;_GNU_SOURCE;ASIO_HAS_STD_ADDRESSOF;ASIO_HAS_STD_ARRAY;ASIO_HAS_CSTDINT;ASIO_HAS_STD_SHARED_PTR;ASIO_HAS_STD_TYPE_TRAITS;ASIO_STANDALONE;RPCLIB_ASIO=clmdep_asio;RPCLIB_FMT=clmdep_fmt;RPCLIB_WIN32;RPCLIB_MSGPACK=clmdep_msgpack;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <CompileAs>CompileAsCpp</CompileAs>
       <InlineFunctionExpansion>Disabled</InlineFunctionExpansion>
       <RuntimeTypeInfo>true</RuntimeTypeInfo>
@@ -158,7 +158,7 @@
       </FunctionLevelLinking>
       <IntrinsicFunctions>false</IntrinsicFunctions>
       <AdditionalIncludeDirectories>$(SolutionDir)..\..\include;$(SolutionDir)..\..\dependencies\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <PreprocessorDefinitions>WIN32;_WINDOWS;WIN32_LEAN_AND_MEAN;NOMINMAX;VC_EXTRALEAN;_CRT_SECURE_NO_WARNINGS;_CRT_NONSTDC_NO_DEPRECATE;_WIN32_WINNT=0x0501;_GNU_SOURCE;ASIO_HAS_STD_ADDRESSOF;ASIO_HAS_STD_ARRAY;ASIO_HAS_CSTDINT;ASIO_HAS_STD_SHARED_PTR;ASIO_HAS_STD_TYPE_TRAITS;ASIO_STANDALONE;RPCLIB_ASIO=clmdep_asio;RPCLIB_FMT=clmdep_fmt;RPCLIB_WIN32;RPCLIB_MSGPACK=clmdep_msgpack;NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>ES_MODIFICATIONS;WIN32;_WINDOWS;WIN32_LEAN_AND_MEAN;NOMINMAX;VC_EXTRALEAN;_CRT_SECURE_NO_WARNINGS;_CRT_NONSTDC_NO_DEPRECATE;_WIN32_WINNT=0x0501;_GNU_SOURCE;ASIO_HAS_STD_ADDRESSOF;ASIO_HAS_STD_ARRAY;ASIO_HAS_CSTDINT;ASIO_HAS_STD_SHARED_PTR;ASIO_HAS_STD_TYPE_TRAITS;ASIO_STANDALONE;RPCLIB_ASIO=clmdep_asio;RPCLIB_FMT=clmdep_fmt;RPCLIB_WIN32;RPCLIB_MSGPACK=clmdep_msgpack;NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <CompileAs>CompileAsCpp</CompileAs>
       <InlineFunctionExpansion>OnlyExplicitInline</InlineFunctionExpansion>
       <RuntimeTypeInfo>true</RuntimeTypeInfo>
@@ -188,7 +188,7 @@
       </FunctionLevelLinking>
       <IntrinsicFunctions>false</IntrinsicFunctions>
       <AdditionalIncludeDirectories>$(SolutionDir)..\..\include;$(SolutionDir)..\..\dependencies\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <PreprocessorDefinitions>WIN32;_WINDOWS;WIN32_LEAN_AND_MEAN;NOMINMAX;VC_EXTRALEAN;_CRT_SECURE_NO_WARNINGS;_CRT_NONSTDC_NO_DEPRECATE;_WIN32_WINNT=0x0501;_GNU_SOURCE;ASIO_HAS_STD_ADDRESSOF;ASIO_HAS_STD_ARRAY;ASIO_HAS_CSTDINT;ASIO_HAS_STD_SHARED_PTR;ASIO_HAS_STD_TYPE_TRAITS;ASIO_STANDALONE;RPCLIB_ASIO=clmdep_asio;RPCLIB_FMT=clmdep_fmt;RPCLIB_WIN32;RPCLIB_MSGPACK=clmdep_msgpack;NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>ES_MODIFICATIONS;WIN32;_WINDOWS;WIN32_LEAN_AND_MEAN;NOMINMAX;VC_EXTRALEAN;_CRT_SECURE_NO_WARNINGS;_CRT_NONSTDC_NO_DEPRECATE;_WIN32_WINNT=0x0501;_GNU_SOURCE;ASIO_HAS_STD_ADDRESSOF;ASIO_HAS_STD_ARRAY;ASIO_HAS_CSTDINT;ASIO_HAS_STD_SHARED_PTR;ASIO_HAS_STD_TYPE_TRAITS;ASIO_STANDALONE;RPCLIB_ASIO=clmdep_asio;RPCLIB_FMT=clmdep_fmt;RPCLIB_WIN32;RPCLIB_MSGPACK=clmdep_msgpack;NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <CompileAs>CompileAsCpp</CompileAs>
       <InlineFunctionExpansion>OnlyExplicitInline</InlineFunctionExpansion>
       <RuntimeTypeInfo>true</RuntimeTypeInfo>

--- a/vc14.1/rpclib/rcplib.windows/rpclib.windows.vcxproj
+++ b/vc14.1/rpclib/rcplib.windows/rpclib.windows.vcxproj
@@ -111,7 +111,7 @@
       <SDLCheck>
       </SDLCheck>
       <AdditionalIncludeDirectories>$(SolutionDir)..\..\include;$(SolutionDir)..\..\dependencies\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <PreprocessorDefinitions>ES_RPCLIB_MODIFICATIONS;WIN32;_WINDOWS;WIN32_LEAN_AND_MEAN;NOMINMAX;VC_EXTRALEAN;_CRT_SECURE_NO_WARNINGS;_CRT_NONSTDC_NO_DEPRECATE;_WIN32_WINNT=0x0501;_GNU_SOURCE;ASIO_HAS_STD_ADDRESSOF;ASIO_HAS_STD_ARRAY;ASIO_HAS_CSTDINT;ASIO_HAS_STD_SHARED_PTR;ASIO_HAS_STD_TYPE_TRAITS;ASIO_STANDALONE;RPCLIB_ASIO=clmdep_asio;RPCLIB_FMT=clmdep_fmt;RPCLIB_WIN32;RPCLIB_MSGPACK=clmdep_msgpack;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>ES_ALLOW_WSA_INCOMPATIBLE_CODE=0;WIN32;_WINDOWS;WIN32_LEAN_AND_MEAN;NOMINMAX;VC_EXTRALEAN;_CRT_SECURE_NO_WARNINGS;_CRT_NONSTDC_NO_DEPRECATE;_WIN32_WINNT=0x0501;_GNU_SOURCE;ASIO_HAS_STD_ADDRESSOF;ASIO_HAS_STD_ARRAY;ASIO_HAS_CSTDINT;ASIO_HAS_STD_SHARED_PTR;ASIO_HAS_STD_TYPE_TRAITS;ASIO_STANDALONE;RPCLIB_ASIO=clmdep_asio;RPCLIB_FMT=clmdep_fmt;RPCLIB_WIN32;RPCLIB_MSGPACK=clmdep_msgpack;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <CompileAs>CompileAsCpp</CompileAs>
       <InlineFunctionExpansion>Disabled</InlineFunctionExpansion>
       <RuntimeTypeInfo>true</RuntimeTypeInfo>
@@ -134,7 +134,7 @@
       <SDLCheck>
       </SDLCheck>
       <AdditionalIncludeDirectories>$(SolutionDir)..\..\include;$(SolutionDir)..\..\dependencies\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <PreprocessorDefinitions>ES_RPCLIB_MODIFICATIONS;WIN32;_WINDOWS;WIN32_LEAN_AND_MEAN;NOMINMAX;VC_EXTRALEAN;_CRT_SECURE_NO_WARNINGS;_CRT_NONSTDC_NO_DEPRECATE;_WIN32_WINNT=0x0501;_GNU_SOURCE;ASIO_HAS_STD_ADDRESSOF;ASIO_HAS_STD_ARRAY;ASIO_HAS_CSTDINT;ASIO_HAS_STD_SHARED_PTR;ASIO_HAS_STD_TYPE_TRAITS;ASIO_STANDALONE;RPCLIB_ASIO=clmdep_asio;RPCLIB_FMT=clmdep_fmt;RPCLIB_WIN32;RPCLIB_MSGPACK=clmdep_msgpack;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>ES_ALLOW_WSA_INCOMPATIBLE_CODE=0;WIN32;_WINDOWS;WIN32_LEAN_AND_MEAN;NOMINMAX;VC_EXTRALEAN;_CRT_SECURE_NO_WARNINGS;_CRT_NONSTDC_NO_DEPRECATE;_WIN32_WINNT=0x0501;_GNU_SOURCE;ASIO_HAS_STD_ADDRESSOF;ASIO_HAS_STD_ARRAY;ASIO_HAS_CSTDINT;ASIO_HAS_STD_SHARED_PTR;ASIO_HAS_STD_TYPE_TRAITS;ASIO_STANDALONE;RPCLIB_ASIO=clmdep_asio;RPCLIB_FMT=clmdep_fmt;RPCLIB_WIN32;RPCLIB_MSGPACK=clmdep_msgpack;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <CompileAs>CompileAsCpp</CompileAs>
       <InlineFunctionExpansion>Disabled</InlineFunctionExpansion>
       <RuntimeTypeInfo>true</RuntimeTypeInfo>
@@ -158,7 +158,7 @@
       </FunctionLevelLinking>
       <IntrinsicFunctions>false</IntrinsicFunctions>
       <AdditionalIncludeDirectories>$(SolutionDir)..\..\include;$(SolutionDir)..\..\dependencies\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <PreprocessorDefinitions>ES_RPCLIB_MODIFICATIONS;WIN32;_WINDOWS;WIN32_LEAN_AND_MEAN;NOMINMAX;VC_EXTRALEAN;_CRT_SECURE_NO_WARNINGS;_CRT_NONSTDC_NO_DEPRECATE;_WIN32_WINNT=0x0501;_GNU_SOURCE;ASIO_HAS_STD_ADDRESSOF;ASIO_HAS_STD_ARRAY;ASIO_HAS_CSTDINT;ASIO_HAS_STD_SHARED_PTR;ASIO_HAS_STD_TYPE_TRAITS;ASIO_STANDALONE;RPCLIB_ASIO=clmdep_asio;RPCLIB_FMT=clmdep_fmt;RPCLIB_WIN32;RPCLIB_MSGPACK=clmdep_msgpack;NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>ES_ALLOW_WSA_INCOMPATIBLE_CODE=0;WIN32;_WINDOWS;WIN32_LEAN_AND_MEAN;NOMINMAX;VC_EXTRALEAN;_CRT_SECURE_NO_WARNINGS;_CRT_NONSTDC_NO_DEPRECATE;_WIN32_WINNT=0x0501;_GNU_SOURCE;ASIO_HAS_STD_ADDRESSOF;ASIO_HAS_STD_ARRAY;ASIO_HAS_CSTDINT;ASIO_HAS_STD_SHARED_PTR;ASIO_HAS_STD_TYPE_TRAITS;ASIO_STANDALONE;RPCLIB_ASIO=clmdep_asio;RPCLIB_FMT=clmdep_fmt;RPCLIB_WIN32;RPCLIB_MSGPACK=clmdep_msgpack;NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <CompileAs>CompileAsCpp</CompileAs>
       <InlineFunctionExpansion>OnlyExplicitInline</InlineFunctionExpansion>
       <RuntimeTypeInfo>true</RuntimeTypeInfo>
@@ -188,7 +188,7 @@
       </FunctionLevelLinking>
       <IntrinsicFunctions>false</IntrinsicFunctions>
       <AdditionalIncludeDirectories>$(SolutionDir)..\..\include;$(SolutionDir)..\..\dependencies\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <PreprocessorDefinitions>ES_RPCLIB_MODIFICATIONS;WIN32;_WINDOWS;WIN32_LEAN_AND_MEAN;NOMINMAX;VC_EXTRALEAN;_CRT_SECURE_NO_WARNINGS;_CRT_NONSTDC_NO_DEPRECATE;_WIN32_WINNT=0x0501;_GNU_SOURCE;ASIO_HAS_STD_ADDRESSOF;ASIO_HAS_STD_ARRAY;ASIO_HAS_CSTDINT;ASIO_HAS_STD_SHARED_PTR;ASIO_HAS_STD_TYPE_TRAITS;ASIO_STANDALONE;RPCLIB_ASIO=clmdep_asio;RPCLIB_FMT=clmdep_fmt;RPCLIB_WIN32;RPCLIB_MSGPACK=clmdep_msgpack;NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>ES_ALLOW_WSA_INCOMPATIBLE_CODE=0;WIN32;_WINDOWS;WIN32_LEAN_AND_MEAN;NOMINMAX;VC_EXTRALEAN;_CRT_SECURE_NO_WARNINGS;_CRT_NONSTDC_NO_DEPRECATE;_WIN32_WINNT=0x0501;_GNU_SOURCE;ASIO_HAS_STD_ADDRESSOF;ASIO_HAS_STD_ARRAY;ASIO_HAS_CSTDINT;ASIO_HAS_STD_SHARED_PTR;ASIO_HAS_STD_TYPE_TRAITS;ASIO_STANDALONE;RPCLIB_ASIO=clmdep_asio;RPCLIB_FMT=clmdep_fmt;RPCLIB_WIN32;RPCLIB_MSGPACK=clmdep_msgpack;NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <CompileAs>CompileAsCpp</CompileAs>
       <InlineFunctionExpansion>OnlyExplicitInline</InlineFunctionExpansion>
       <RuntimeTypeInfo>true</RuntimeTypeInfo>

--- a/vc14.1/rpclib/rcplib.windows/rpclib.windows.vcxproj
+++ b/vc14.1/rpclib/rcplib.windows/rpclib.windows.vcxproj
@@ -111,7 +111,7 @@
       <SDLCheck>
       </SDLCheck>
       <AdditionalIncludeDirectories>$(SolutionDir)..\..\include;$(SolutionDir)..\..\dependencies\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <PreprocessorDefinitions>ES_MODIFICATIONS;WIN32;_WINDOWS;WIN32_LEAN_AND_MEAN;NOMINMAX;VC_EXTRALEAN;_CRT_SECURE_NO_WARNINGS;_CRT_NONSTDC_NO_DEPRECATE;_WIN32_WINNT=0x0501;_GNU_SOURCE;ASIO_HAS_STD_ADDRESSOF;ASIO_HAS_STD_ARRAY;ASIO_HAS_CSTDINT;ASIO_HAS_STD_SHARED_PTR;ASIO_HAS_STD_TYPE_TRAITS;ASIO_STANDALONE;RPCLIB_ASIO=clmdep_asio;RPCLIB_FMT=clmdep_fmt;RPCLIB_WIN32;RPCLIB_MSGPACK=clmdep_msgpack;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>ES_RPCLIB_MODIFICATIONS;WIN32;_WINDOWS;WIN32_LEAN_AND_MEAN;NOMINMAX;VC_EXTRALEAN;_CRT_SECURE_NO_WARNINGS;_CRT_NONSTDC_NO_DEPRECATE;_WIN32_WINNT=0x0501;_GNU_SOURCE;ASIO_HAS_STD_ADDRESSOF;ASIO_HAS_STD_ARRAY;ASIO_HAS_CSTDINT;ASIO_HAS_STD_SHARED_PTR;ASIO_HAS_STD_TYPE_TRAITS;ASIO_STANDALONE;RPCLIB_ASIO=clmdep_asio;RPCLIB_FMT=clmdep_fmt;RPCLIB_WIN32;RPCLIB_MSGPACK=clmdep_msgpack;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <CompileAs>CompileAsCpp</CompileAs>
       <InlineFunctionExpansion>Disabled</InlineFunctionExpansion>
       <RuntimeTypeInfo>true</RuntimeTypeInfo>
@@ -134,7 +134,7 @@
       <SDLCheck>
       </SDLCheck>
       <AdditionalIncludeDirectories>$(SolutionDir)..\..\include;$(SolutionDir)..\..\dependencies\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <PreprocessorDefinitions>ES_MODIFICATIONS;WIN32;_WINDOWS;WIN32_LEAN_AND_MEAN;NOMINMAX;VC_EXTRALEAN;_CRT_SECURE_NO_WARNINGS;_CRT_NONSTDC_NO_DEPRECATE;_WIN32_WINNT=0x0501;_GNU_SOURCE;ASIO_HAS_STD_ADDRESSOF;ASIO_HAS_STD_ARRAY;ASIO_HAS_CSTDINT;ASIO_HAS_STD_SHARED_PTR;ASIO_HAS_STD_TYPE_TRAITS;ASIO_STANDALONE;RPCLIB_ASIO=clmdep_asio;RPCLIB_FMT=clmdep_fmt;RPCLIB_WIN32;RPCLIB_MSGPACK=clmdep_msgpack;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>ES_RPCLIB_MODIFICATIONS;WIN32;_WINDOWS;WIN32_LEAN_AND_MEAN;NOMINMAX;VC_EXTRALEAN;_CRT_SECURE_NO_WARNINGS;_CRT_NONSTDC_NO_DEPRECATE;_WIN32_WINNT=0x0501;_GNU_SOURCE;ASIO_HAS_STD_ADDRESSOF;ASIO_HAS_STD_ARRAY;ASIO_HAS_CSTDINT;ASIO_HAS_STD_SHARED_PTR;ASIO_HAS_STD_TYPE_TRAITS;ASIO_STANDALONE;RPCLIB_ASIO=clmdep_asio;RPCLIB_FMT=clmdep_fmt;RPCLIB_WIN32;RPCLIB_MSGPACK=clmdep_msgpack;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <CompileAs>CompileAsCpp</CompileAs>
       <InlineFunctionExpansion>Disabled</InlineFunctionExpansion>
       <RuntimeTypeInfo>true</RuntimeTypeInfo>
@@ -158,7 +158,7 @@
       </FunctionLevelLinking>
       <IntrinsicFunctions>false</IntrinsicFunctions>
       <AdditionalIncludeDirectories>$(SolutionDir)..\..\include;$(SolutionDir)..\..\dependencies\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <PreprocessorDefinitions>ES_MODIFICATIONS;WIN32;_WINDOWS;WIN32_LEAN_AND_MEAN;NOMINMAX;VC_EXTRALEAN;_CRT_SECURE_NO_WARNINGS;_CRT_NONSTDC_NO_DEPRECATE;_WIN32_WINNT=0x0501;_GNU_SOURCE;ASIO_HAS_STD_ADDRESSOF;ASIO_HAS_STD_ARRAY;ASIO_HAS_CSTDINT;ASIO_HAS_STD_SHARED_PTR;ASIO_HAS_STD_TYPE_TRAITS;ASIO_STANDALONE;RPCLIB_ASIO=clmdep_asio;RPCLIB_FMT=clmdep_fmt;RPCLIB_WIN32;RPCLIB_MSGPACK=clmdep_msgpack;NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>ES_RPCLIB_MODIFICATIONS;WIN32;_WINDOWS;WIN32_LEAN_AND_MEAN;NOMINMAX;VC_EXTRALEAN;_CRT_SECURE_NO_WARNINGS;_CRT_NONSTDC_NO_DEPRECATE;_WIN32_WINNT=0x0501;_GNU_SOURCE;ASIO_HAS_STD_ADDRESSOF;ASIO_HAS_STD_ARRAY;ASIO_HAS_CSTDINT;ASIO_HAS_STD_SHARED_PTR;ASIO_HAS_STD_TYPE_TRAITS;ASIO_STANDALONE;RPCLIB_ASIO=clmdep_asio;RPCLIB_FMT=clmdep_fmt;RPCLIB_WIN32;RPCLIB_MSGPACK=clmdep_msgpack;NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <CompileAs>CompileAsCpp</CompileAs>
       <InlineFunctionExpansion>OnlyExplicitInline</InlineFunctionExpansion>
       <RuntimeTypeInfo>true</RuntimeTypeInfo>
@@ -188,7 +188,7 @@
       </FunctionLevelLinking>
       <IntrinsicFunctions>false</IntrinsicFunctions>
       <AdditionalIncludeDirectories>$(SolutionDir)..\..\include;$(SolutionDir)..\..\dependencies\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <PreprocessorDefinitions>ES_MODIFICATIONS;WIN32;_WINDOWS;WIN32_LEAN_AND_MEAN;NOMINMAX;VC_EXTRALEAN;_CRT_SECURE_NO_WARNINGS;_CRT_NONSTDC_NO_DEPRECATE;_WIN32_WINNT=0x0501;_GNU_SOURCE;ASIO_HAS_STD_ADDRESSOF;ASIO_HAS_STD_ARRAY;ASIO_HAS_CSTDINT;ASIO_HAS_STD_SHARED_PTR;ASIO_HAS_STD_TYPE_TRAITS;ASIO_STANDALONE;RPCLIB_ASIO=clmdep_asio;RPCLIB_FMT=clmdep_fmt;RPCLIB_WIN32;RPCLIB_MSGPACK=clmdep_msgpack;NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>ES_RPCLIB_MODIFICATIONS;WIN32;_WINDOWS;WIN32_LEAN_AND_MEAN;NOMINMAX;VC_EXTRALEAN;_CRT_SECURE_NO_WARNINGS;_CRT_NONSTDC_NO_DEPRECATE;_WIN32_WINNT=0x0501;_GNU_SOURCE;ASIO_HAS_STD_ADDRESSOF;ASIO_HAS_STD_ARRAY;ASIO_HAS_CSTDINT;ASIO_HAS_STD_SHARED_PTR;ASIO_HAS_STD_TYPE_TRAITS;ASIO_STANDALONE;RPCLIB_ASIO=clmdep_asio;RPCLIB_FMT=clmdep_fmt;RPCLIB_WIN32;RPCLIB_MSGPACK=clmdep_msgpack;NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <CompileAs>CompileAsCpp</CompileAs>
       <InlineFunctionExpansion>OnlyExplicitInline</InlineFunctionExpansion>
       <RuntimeTypeInfo>true</RuntimeTypeInfo>

--- a/vc14.1/rpclib/rpclib.android/rpclib.android.vcxproj
+++ b/vc14.1/rpclib/rpclib.android/rpclib.android.vcxproj
@@ -215,7 +215,7 @@
       <AdditionalIncludeDirectories>$(SolutionDir)..\..\include;$(SolutionDir)..\..\dependencies\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <ExceptionHandling>Enabled</ExceptionHandling>
       <AdditionalOptions>-std=c++11</AdditionalOptions>
-      <PreprocessorDefinitions>NOMINMAX;_GNU_SOURCE;ASIO_HAS_STD_ADDRESSOF;ASIO_HAS_STD_ARRAY;ASIO_HAS_CSTDINT;ASIO_HAS_STD_SHARED_PTR;ASIO_HAS_STD_TYPE_TRAITS;ASIO_STANDALONE;RPCLIB_ASIO=clmdep_asio;RPCLIB_FMT=clmdep_fmt;RPCLIB_MSGPACK=clmdep_msgpack;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>ES_MODIFICATIONS;NOMINMAX;_GNU_SOURCE;ASIO_HAS_STD_ADDRESSOF;ASIO_HAS_STD_ARRAY;ASIO_HAS_CSTDINT;ASIO_HAS_STD_SHARED_PTR;ASIO_HAS_STD_TYPE_TRAITS;ASIO_STANDALONE;RPCLIB_ASIO=clmdep_asio;RPCLIB_FMT=clmdep_fmt;RPCLIB_MSGPACK=clmdep_msgpack;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeTypeInfo>true</RuntimeTypeInfo>
     </ClCompile>
   </ItemDefinitionGroup>
@@ -227,7 +227,7 @@
       <AdditionalIncludeDirectories>$(SolutionDir)..\..\include;$(SolutionDir)..\..\dependencies\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <ExceptionHandling>Enabled</ExceptionHandling>
       <AdditionalOptions>-std=c++11</AdditionalOptions>
-      <PreprocessorDefinitions>NOMINMAX;_GNU_SOURCE;ASIO_HAS_STD_ADDRESSOF;ASIO_HAS_STD_ARRAY;ASIO_HAS_CSTDINT;ASIO_HAS_STD_SHARED_PTR;ASIO_HAS_STD_TYPE_TRAITS;ASIO_STANDALONE;RPCLIB_ASIO=clmdep_asio;RPCLIB_FMT=clmdep_fmt;RPCLIB_MSGPACK=clmdep_msgpack;NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>ES_MODIFICATIONS;NOMINMAX;_GNU_SOURCE;ASIO_HAS_STD_ADDRESSOF;ASIO_HAS_STD_ARRAY;ASIO_HAS_CSTDINT;ASIO_HAS_STD_SHARED_PTR;ASIO_HAS_STD_TYPE_TRAITS;ASIO_STANDALONE;RPCLIB_ASIO=clmdep_asio;RPCLIB_FMT=clmdep_fmt;RPCLIB_MSGPACK=clmdep_msgpack;NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeTypeInfo>true</RuntimeTypeInfo>
     </ClCompile>
   </ItemDefinitionGroup>

--- a/vc14.1/rpclib/rpclib.android/rpclib.android.vcxproj
+++ b/vc14.1/rpclib/rpclib.android/rpclib.android.vcxproj
@@ -215,7 +215,7 @@
       <AdditionalIncludeDirectories>$(SolutionDir)..\..\include;$(SolutionDir)..\..\dependencies\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <ExceptionHandling>Enabled</ExceptionHandling>
       <AdditionalOptions>-std=c++11</AdditionalOptions>
-      <PreprocessorDefinitions>ES_RPCLIB_MODIFICATIONS;NOMINMAX;_GNU_SOURCE;ASIO_HAS_STD_ADDRESSOF;ASIO_HAS_STD_ARRAY;ASIO_HAS_CSTDINT;ASIO_HAS_STD_SHARED_PTR;ASIO_HAS_STD_TYPE_TRAITS;ASIO_STANDALONE;RPCLIB_ASIO=clmdep_asio;RPCLIB_FMT=clmdep_fmt;RPCLIB_MSGPACK=clmdep_msgpack;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>ES_ALLOW_WSA_INCOMPATIBLE_CODE=0;NOMINMAX;_GNU_SOURCE;ASIO_HAS_STD_ADDRESSOF;ASIO_HAS_STD_ARRAY;ASIO_HAS_CSTDINT;ASIO_HAS_STD_SHARED_PTR;ASIO_HAS_STD_TYPE_TRAITS;ASIO_STANDALONE;RPCLIB_ASIO=clmdep_asio;RPCLIB_FMT=clmdep_fmt;RPCLIB_MSGPACK=clmdep_msgpack;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeTypeInfo>true</RuntimeTypeInfo>
     </ClCompile>
   </ItemDefinitionGroup>
@@ -227,7 +227,7 @@
       <AdditionalIncludeDirectories>$(SolutionDir)..\..\include;$(SolutionDir)..\..\dependencies\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <ExceptionHandling>Enabled</ExceptionHandling>
       <AdditionalOptions>-std=c++11</AdditionalOptions>
-      <PreprocessorDefinitions>ES_RPCLIB_MODIFICATIONS;NOMINMAX;_GNU_SOURCE;ASIO_HAS_STD_ADDRESSOF;ASIO_HAS_STD_ARRAY;ASIO_HAS_CSTDINT;ASIO_HAS_STD_SHARED_PTR;ASIO_HAS_STD_TYPE_TRAITS;ASIO_STANDALONE;RPCLIB_ASIO=clmdep_asio;RPCLIB_FMT=clmdep_fmt;RPCLIB_MSGPACK=clmdep_msgpack;NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>ES_ALLOW_WSA_INCOMPATIBLE_CODE=0;NOMINMAX;_GNU_SOURCE;ASIO_HAS_STD_ADDRESSOF;ASIO_HAS_STD_ARRAY;ASIO_HAS_CSTDINT;ASIO_HAS_STD_SHARED_PTR;ASIO_HAS_STD_TYPE_TRAITS;ASIO_STANDALONE;RPCLIB_ASIO=clmdep_asio;RPCLIB_FMT=clmdep_fmt;RPCLIB_MSGPACK=clmdep_msgpack;NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeTypeInfo>true</RuntimeTypeInfo>
     </ClCompile>
   </ItemDefinitionGroup>

--- a/vc14.1/rpclib/rpclib.android/rpclib.android.vcxproj
+++ b/vc14.1/rpclib/rpclib.android/rpclib.android.vcxproj
@@ -215,7 +215,7 @@
       <AdditionalIncludeDirectories>$(SolutionDir)..\..\include;$(SolutionDir)..\..\dependencies\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <ExceptionHandling>Enabled</ExceptionHandling>
       <AdditionalOptions>-std=c++11</AdditionalOptions>
-      <PreprocessorDefinitions>ES_MODIFICATIONS;NOMINMAX;_GNU_SOURCE;ASIO_HAS_STD_ADDRESSOF;ASIO_HAS_STD_ARRAY;ASIO_HAS_CSTDINT;ASIO_HAS_STD_SHARED_PTR;ASIO_HAS_STD_TYPE_TRAITS;ASIO_STANDALONE;RPCLIB_ASIO=clmdep_asio;RPCLIB_FMT=clmdep_fmt;RPCLIB_MSGPACK=clmdep_msgpack;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>ES_RPCLIB_MODIFICATIONS;NOMINMAX;_GNU_SOURCE;ASIO_HAS_STD_ADDRESSOF;ASIO_HAS_STD_ARRAY;ASIO_HAS_CSTDINT;ASIO_HAS_STD_SHARED_PTR;ASIO_HAS_STD_TYPE_TRAITS;ASIO_STANDALONE;RPCLIB_ASIO=clmdep_asio;RPCLIB_FMT=clmdep_fmt;RPCLIB_MSGPACK=clmdep_msgpack;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeTypeInfo>true</RuntimeTypeInfo>
     </ClCompile>
   </ItemDefinitionGroup>
@@ -227,7 +227,7 @@
       <AdditionalIncludeDirectories>$(SolutionDir)..\..\include;$(SolutionDir)..\..\dependencies\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <ExceptionHandling>Enabled</ExceptionHandling>
       <AdditionalOptions>-std=c++11</AdditionalOptions>
-      <PreprocessorDefinitions>ES_MODIFICATIONS;NOMINMAX;_GNU_SOURCE;ASIO_HAS_STD_ADDRESSOF;ASIO_HAS_STD_ARRAY;ASIO_HAS_CSTDINT;ASIO_HAS_STD_SHARED_PTR;ASIO_HAS_STD_TYPE_TRAITS;ASIO_STANDALONE;RPCLIB_ASIO=clmdep_asio;RPCLIB_FMT=clmdep_fmt;RPCLIB_MSGPACK=clmdep_msgpack;NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>ES_RPCLIB_MODIFICATIONS;NOMINMAX;_GNU_SOURCE;ASIO_HAS_STD_ADDRESSOF;ASIO_HAS_STD_ARRAY;ASIO_HAS_CSTDINT;ASIO_HAS_STD_SHARED_PTR;ASIO_HAS_STD_TYPE_TRAITS;ASIO_STANDALONE;RPCLIB_ASIO=clmdep_asio;RPCLIB_FMT=clmdep_fmt;RPCLIB_MSGPACK=clmdep_msgpack;NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeTypeInfo>true</RuntimeTypeInfo>
     </ClCompile>
   </ItemDefinitionGroup>


### PR DESCRIPTION
See: https://blog.csdn.net/netyeaxi/article/details/82499698 for more
info.

Essentially, when compiling the project with exceptions enabled (on Win64), bad_cast becomes `#if`'d out as the Microsoft stl headers do that for some reason.

See:
```C++
#if !(_HAS_EXCEPTIONS)
 
        // CLASS bad_cast
class _CRTIMP2_IMPORT bad_cast
    : public exception
    {    // base of all bad cast exceptions
public:
    bad_cast(const char *_Message = "bad cast") noexcept
        : exception(_Message)
        {    // construct from message string
        }
 
    virtual ~bad_cast() noexcept
        {    // destroy the object
        }
 
protected:
    virtual void _Doraise() const
        {    // perform class-specific exception handling
        _RAISE(*this);
        }
    };
 
        // CLASS bad_typeid
class _CRTIMP2_IMPORT bad_typeid
    : public exception
    {    // base of all bad typeid exceptions
public:
    bad_typeid(const char *_Message = "bad typeid") noexcept
        : exception(_Message)
        {    // construct from message string
        }
 
    virtual ~bad_typeid() noexcept
        {    // destroy the object
        }
 
protected:
    virtual void _Doraise() const
        {    // perform class-specific exception handling
        _RAISE(*this);
        }
    };
 
class _CRTIMP2_IMPORT __non_rtti_object
    : public bad_typeid
    {    // report a non RTTI object
public:
    __non_rtti_object(const char *_Message)
        : bad_typeid(_Message)
        {    // construct from message string
        }
    };
 #endif /* _HAS_EXCEPTIONS */
```
In `<typeinfo>`
